### PR TITLE
Add python-corona-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A curated list of projects using the NovelCOVID API
 | Link  | Description  | Author |
 |:------|:-------------|:-------|
 | [COVIDAPI](https://npmjs.com/covidapi) | An always up-to-date JavaScript API Wrapper. | [puf17640](https://github.com/puf17640)
+| [corona-api](https://pypi.org/project/corona-api) | An always up-to-date Python API Wrapper. | [apex2504](https://github.com/apex2504)
 
 ## Other
 


### PR DESCRIPTION
As far as I am aware, this is the only fully up-to-date and consistently maintained wrapper for the API in Python.

Project link: https://github.com/apex2504/python-corona-api

Installation is simply `pip install -U corona-api` on Windows or `python3 -m pip install -U corona-api` on Linux.